### PR TITLE
Add rain.thecomicseries.com to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11037,6 +11037,21 @@ INVERT
 
 ================================
 
+rain.thecomicseries.com
+
+CSS
+html {
+    background-color: revert !important;
+}
+body {
+    background-color: #333333 !important;
+}
+#comicimage {
+    background-color: #ffffff !important;
+}
+
+================================
+
 rapidtables.com
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
This fixes a few issues with the webcomic's webpage using this. The page expects a few background colors to be specific values, so this fixes some CSS attributes to make it work correctly.

* By default, `body` tags have a small margin. On the website, the `html` tag doesn't have a background color, so this margin just uses the body's background. Dark Reader adds a background color attribute to the `html`, which causes a border to appear on the website. This removes the background color value so the body's background is used instead.
* The `body`'s background works by using a gradient PNG, followed by a fixed background color to continue the end of the gradient. Dynamic mode doesn't affect the background gradient, but does change the background color, which breaks the continuous color. This sets the background color to what it was originally.
* The comic pages on occasion have transparency (usually on multi-page posts) which expect the background color behind it to be white. This extension changes the background color, which messes it up a bit. This sets the background color for the `img` tag to white so that the image transparency works as intended.

The only other thing that I noticed was that the border color around the main `#container` is the same as its background color both on the original site and in light mode, but is different in dark mode. Attempting to fix this by setting the border color to transparent looked worse due to the background gradient, so it seems that having the border color helps. If anything, the border color should maybe be forced to be brighter than the gradient, but I couldn't figure out a good way of doing that, so I left that out.